### PR TITLE
fix: update mcp dependency version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pytest>=7.4.4",
     "pytest-asyncio>=0.23.0",
     "ruff>=0.11.5",
-    "mcp==1.0.0",
+    "mcp>=1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Changed mcp==1.0.0 to mcp>=1.0.0 to allow newer versions
- Fixes Python version compatibility issues
- Enables installation with Python 3.10+

🤖 Generated with [Claude Code](https://claude.ai/code)